### PR TITLE
[0.4.0] Validate that an associate is a member of the org in some way

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ Based on the org that this tool was originally designed for, orgs are expected
 to have three levels:
 
 * *squads*: the base unit of team-dom, containing people, who may be in
-  different geographical regions.
+  different geographical regions. Teams contain _members_ (full time heads)
+  and _associates_ (typically part time floaters.) Any associate of a squad
+  must also have a home squad for which they are a full time member.
 * *platoons*: a unit which contains squads and exceptional people who are
   members of the platoon, but not part of any squad
 * *org*: The whole organization, including its manager, any exceptional squads

--- a/lib/terraorg/model/org.rb
+++ b/lib/terraorg/model/org.rb
@@ -97,7 +97,8 @@ class Org
     # across the entire org. A person can be an associate of other squads
     # at a different count. See top of file for defined limits.
     squad_count = {}
-    all_squads.map(&:teams).flatten.map(&:values).flatten.map(&:members).flatten.each do |member|
+    all_members = all_squads.map(&:teams).flatten.map(&:values).flatten.map(&:members).flatten
+    all_members.each do |member|
       squad_count[member.id] = squad_count.fetch(member.id, 0) + 1
     end
     more_than_max_squads = squad_count.select do |member, count|
@@ -109,7 +110,8 @@ class Org
     end
 
     associate_count = {}
-    all_squads.map(&:teams).flatten.map(&:values).flatten.map(&:associates).flatten.each do |assoc|
+    all_associates = all_squads.map(&:teams).flatten.map(&:values).flatten.map(&:associates).flatten
+    all_associates.each do |assoc|
       associate_count[assoc.id] = associate_count.fetch(assoc.id, 0) + 1
     end
     more_than_max_squads = associate_count.select do |_, count|
@@ -127,6 +129,13 @@ class Org
     end
     if !exception_and_squad_member.empty?
       $stderr.puts "ERROR: Exception members are also squad members: #{exception_and_squad_member}"
+      failure = true
+    end
+
+    # Validate that any associate is a member of some squad
+    associates_but_not_members = Set.new(all_associates.map(&:id)) - Set.new(all_members.map(&:id)) - exceptions
+    if !associates_but_not_members.empty?
+      $stderr.puts "ERROR: #{associates_but_not_members.map(&:id)} are associates of squads but not members of any squad"
       failure = true
     end
 

--- a/lib/terraorg/version.rb
+++ b/lib/terraorg/version.rb
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 module Terraorg
-  VERSION = '0.3.0'
+  VERSION = '0.4.0'
 end


### PR DESCRIPTION
With the addition of associate it became possible to make an associate
who is not a member of any squad. Due to the way membership inheritance
is calculated differently for members vs associates (clarified in
README), this resulted in some unintuitive results when this was done at
LR. Fix this by adding a check.