### PR TITLE
Updating ERROR for users with Suspended status

### DIFF
--- a/lib/terraorg/model/org.rb
+++ b/lib/terraorg/model/org.rb
@@ -54,7 +54,7 @@ class Org
 
     # Do not allow the JSON files to contain any people who have left.
     unless @people.inactive.empty?
-      $stderr.puts "ERROR: Users have left the company: #{@people.inactive.map(&:id).join(', ')}"
+      $stderr.puts "ERROR: Users have left the company, or are Suspended in Okta: #{@people.inactive.map(&:id).join(', ')}"
       failure = true
     end
 


### PR DESCRIPTION
Extending error to alert that account may be suspended, not deactivated (or left the company)