### PR TITLE
Added PASSWORD_EXPIRED as a valid state

### DIFF
--- a/lib/terraorg/model/person.rb
+++ b/lib/terraorg/model/person.rb
@@ -15,7 +15,7 @@
 require 'faraday'
 
 class Person
-  ACTIVE_USER_STATUSES = ['ACTIVE', 'PROVISIONED'].freeze
+  ACTIVE_USER_STATUSES = ['ACTIVE', 'PROVISIONED', 'PASSWORD_EXPIRED'].freeze
 
   attr_accessor :id, :name, :okta_id, :email, :status
 

--- a/lib/terraorg/version.rb
+++ b/lib/terraorg/version.rb
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 module Terraorg
-  VERSION = '0.5.2'
+  VERSION = '0.5.3'
 end


### PR DESCRIPTION
Currently Terraorg is forcing us to remove users that simply have an expired passwords when making changes.
We then need to manually add them in later when they return and reset things in Okta. It's pretty annoying