### PR TITLE
Add Suspended as valid acct state

### DIFF
--- a/lib/terraorg/model/person.rb
+++ b/lib/terraorg/model/person.rb
@@ -14,6 +14,9 @@
 
 require 'faraday'
 
+# The following statuses are considered ACTIVE by terraorg, which allow PRs to continue and be merged. 
+# A DEACTIVATED account status needs to be removed from the repository before merging PRs
+
 class Person
   ACTIVE_USER_STATUSES = ['ACTIVE', 'PROVISIONED', 'PASSWORD_EXPIRED', 'SUSPENDED'].freeze
 

--- a/lib/terraorg/model/person.rb
+++ b/lib/terraorg/model/person.rb
@@ -15,7 +15,7 @@
 require 'faraday'
 
 class Person
-  ACTIVE_USER_STATUSES = ['ACTIVE', 'PROVISIONED', 'PASSWORD_EXPIRED'].freeze
+  ACTIVE_USER_STATUSES = ['ACTIVE', 'PROVISIONED', 'PASSWORD_EXPIRED', 'SUSPENDED'].freeze
 
   attr_accessor :id, :name, :okta_id, :email, :status
 

--- a/lib/terraorg/version.rb
+++ b/lib/terraorg/version.rb
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 module Terraorg
-  VERSION = '0.5.3'
+  VERSION = '0.5.4'
 end


### PR DESCRIPTION
Add Okta status SUSPENDED as valid state. This is to prevent users who are in suspended status from blocking eng_meta PRs. Typically, immediate terminations and 60-day inactive accounts result in a Suspended status.
While terra_org could demand the suspended account be removed, it feels pretty heavy-handed. (app depro's and such)