### PR TITLE
Update Active Okta status lists to include RECOVERY

### DIFF
--- a/lib/terraorg/model/person.rb
+++ b/lib/terraorg/model/person.rb
@@ -18,7 +18,7 @@ require 'faraday'
 # A DEACTIVATED account status needs to be removed from the repository before merging PRs
 
 class Person
-  ACTIVE_USER_STATUSES = ['ACTIVE', 'PROVISIONED', 'PASSWORD_EXPIRED', 'SUSPENDED'].freeze
+  ACTIVE_USER_STATUSES = ['ACTIVE', 'PROVISIONED', 'PASSWORD_EXPIRED', 'SUSPENDED', 'RECOVERY'].freeze
 
   attr_accessor :id, :name, :okta_id, :email, :status
 

--- a/lib/terraorg/version.rb
+++ b/lib/terraorg/version.rb
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 module Terraorg
-  VERSION = '0.5.4'
+  VERSION = '0.5.5'
 end


### PR DESCRIPTION
See individual commits for this.

RECOVERY Accounts have a recovery status when a user requests a password reset or an admin initiates one on their behalf.

https://help.okta.com/en-us/Content/Topics/users-groups-profiles/usgp-end-user-states.htm?cshid=ext_end_user_states