### PR TITLE
Add Locked_Out and Recovery as valid account statuses

### DIFF
--- a/lib/terraorg/model/org.rb
+++ b/lib/terraorg/model/org.rb
@@ -55,7 +55,7 @@ class Org
 
     # Do not allow the JSON files to contain any people who have left.
     unless @people.inactive.empty?
-      $stderr.puts "ERROR: Users have left the company, or are Suspended in Okta: #{@people.inactive.map(&:id).join(', ')}"
+      $stderr.puts "ERROR: Users have left the company: #{@people.inactive.map(&:id).join(', ')}"
       failure = true
     end
 

--- a/lib/terraorg/model/person.rb
+++ b/lib/terraorg/model/person.rb
@@ -18,7 +18,7 @@ require 'faraday'
 # A DEACTIVATED account status needs to be removed from the repository before merging PRs
 
 class Person
-  ACTIVE_USER_STATUSES = ['ACTIVE', 'PROVISIONED', 'PASSWORD_EXPIRED', 'SUSPENDED'].freeze
+  ACTIVE_USER_STATUSES = ['ACTIVE', 'PROVISIONED', 'PASSWORD_EXPIRED', 'SUSPENDED', 'LOCKED_OUT'].freeze
 
   attr_accessor :id, :name, :okta_id, :email, :status
 

--- a/lib/terraorg/model/person.rb
+++ b/lib/terraorg/model/person.rb
@@ -18,7 +18,7 @@ require 'faraday'
 # A DEACTIVATED account status needs to be removed from the repository before merging PRs
 
 class Person
-  ACTIVE_USER_STATUSES = ['ACTIVE', 'PROVISIONED', 'PASSWORD_EXPIRED', 'SUSPENDED', 'LOCKED_OUT'].freeze
+  ACTIVE_USER_STATUSES = ['ACTIVE', 'PROVISIONED', 'PASSWORD_EXPIRED', 'SUSPENDED', 'LOCKED_OUT', 'RECOVERY'].freeze
 
   attr_accessor :id, :name, :okta_id, :email, :status
 

--- a/lib/terraorg/version.rb
+++ b/lib/terraorg/version.rb
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 module Terraorg
-  VERSION = '0.5.4'
+  VERSION = '0.5.5'
 end


### PR DESCRIPTION
Add Okta statuses LOCKED_OUT and RECOVERY as valid state. 

This is to prevent eng_meta from getting blocked when users are locked out, typically from too many attempts to enter their password incorrectly. The users do inevitably go back to Active, but the delay can be significant. 

Also updated the failure message for users who have left the company because as of the prior patch to allow suspended users, a user being suspended is no longer blocking. 

Edit: Saw this [prior PR ](https://github.com/joshk0/terraorg/pull/13) to add Recovery as a valid status and added that change to this PR as the prior one was 2 years old and unmerged. 